### PR TITLE
Fix signal delivery

### DIFF
--- a/io.go
+++ b/io.go
@@ -74,7 +74,6 @@ func inLoop(pipe io.WriteCloser, stdin io.Reader, done chan bool) {
 func inLoop2(pipe io.WriteCloser, proc *exec.Cmd, stdin io.Reader, done chan bool) {
 	buf := make([]byte, 3)
 	logger.Println("Entering stdin loop")
-	done <- true
 	loop: for {
 		bytes_read, read_err := io.ReadFull(stdin, buf[:2])
 		if read_err == io.EOF && bytes_read == 0 {
@@ -124,7 +123,6 @@ func inLoop2(pipe io.WriteCloser, proc *exec.Cmd, stdin io.Reader, done chan boo
 	}
 	pipe.Close()
         logger.Println("Exiting stdin loop")
-	done <- true
 }
 
 ///

--- a/io.go
+++ b/io.go
@@ -86,7 +86,8 @@ func inLoop2(pipe io.WriteCloser, proc *exec.Cmd, stdin io.Reader, done chan boo
 		logger.Printf("in: packet length = %v\n", length)
 		if length == 0 {
 			// this is how Porcelain signals EOF from Elixir
-			break
+                        pipe.Close()
+                        continue
 		}
 
 		_, read_err = io.ReadFull(stdin, buf[2:])
@@ -122,6 +123,7 @@ func inLoop2(pipe io.WriteCloser, proc *exec.Cmd, stdin io.Reader, done chan boo
 		}
 	}
 	pipe.Close()
+        logger.Println("Exiting stdin loop")
 	done <- true
 }
 

--- a/proto_2_0.go
+++ b/proto_2_0.go
@@ -19,10 +19,7 @@ func proto_2_0(inFlag, outFlag bool, errFlag, workdir string, args []string) err
 	doneChan := make(chan bool, 3)
 	doneCount := 0
 
-	if inFlag {
-		wrapStdin2(proc, os.Stdin, doneChan)
-		doneCount++
-	}
+        wrapStdin2(proc, os.Stdin, doneChan)
 
 	if outFlag {
 		wrapStdout(proc, os.Stdout, stdoutMarker, doneChan)


### PR DESCRIPTION
Signals were not delivered unless the input pipe was kept open by the elixir program.
The design is still broken (signals still travel synchronously with the data stream) but for most purposes this patch will alleviate the problem.
